### PR TITLE
Restore Analog Mic Boost on quit on XO-{1.75,4}

### DIFF
--- a/audiograb.py
+++ b/audiograb.py
@@ -938,6 +938,15 @@ class AudioGrab_XO175(AudioGrab):
         mode, bias, gain, boost = PARAMETERS[sensor_type]
         self._set_sensor_type(mode, bias, gain, boost)
 
+    def on_activity_quit(self):
+        AudioGrab.on_activity_quit(self)
+        output = check_output(
+            ['amixer', 'set', 'MIC1 Boost', "87%"],
+            'restore MIC1 Boost')  # OLPC OS up to 13.2.5
+        output = check_output(
+            ['amixer', 'set', 'Analog Mic Boost', "62%"],
+            'restore Analog Mic Boost')  # OLPC OS after 13.2.5
+
 
 class AudioGrab_XO4(AudioGrab):
     ''' Override parameters for OLPC XO 4 laptop '''
@@ -952,6 +961,12 @@ class AudioGrab_XO4(AudioGrab):
         log.debug('Set Sensor Type to %s' % (str(sensor_type)))
         mode, bias, gain, boost = PARAMETERS[sensor_type]
         self._set_sensor_type(mode, bias, gain, boost)
+
+    def on_activity_quit(self):
+        AudioGrab.on_activity_quit(self)
+        output = check_output(
+            ['amixer', 'set', 'Analog Mic Boost', "62%"],
+            'restore Analog Mic Boost')
 
 
 class AudioGrab_Unknown(AudioGrab):


### PR DESCRIPTION
Restore the Analog Mic Boost control to the default when the activity
quits.

Audio recording level on XO-1.75 and XO-4 is set by two ALSA mixer
controls, Capture and Analog Mic Boost.  Capture is exposed on the Sugar
Frame as Microphone.  Analog Mic Boost is not exposed, was set to zero
by Measure activity quit (because on earlier models it was a switch, not
a level), and persists at zero over reboots thanks to alsactl.

Test case; try to use Record to capture voice after quit of Measure.

http://dev.laptop.org/ticket/12867
https://github.com/godiard/record-activity/pull/4
