### PR TITLE
Fixes #8 Gst.Pipeline error

### DIFF
--- a/audiograb.py
+++ b/audiograb.py
@@ -123,7 +123,7 @@ class AudioGrab():
         self.pads = []
         self.queue = []
         self.fakesink = []
-        self.pipeline = Gst.Pipeline('pipeline')
+        self.pipeline = Gst.Pipeline.new('pipeline')
         self.alsasrc = Gst.ElementFactory.make('alsasrc', 'alsa-source')
         self.pipeline.add(self.alsasrc)
         self.caps1 = Gst.ElementFactory.make('capsfilter', 'caps1')


### PR DESCRIPTION
Uses Gst.Pipeline.new to create a named pipeline. Tested on sugar-build running on a 64-bit Fedora 24 machine.

See https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer/html/GstPipeline.html for Pipeline documentation.